### PR TITLE
Added .gitignore to files that are templated

### DIFF
--- a/cmd/newcmd/check.go
+++ b/cmd/newcmd/check.go
@@ -17,6 +17,7 @@ var (
 		"LICENSE",
 		"main.go",
 		"README.md",
+		".gitignore",
 	}
 )
 

--- a/cmd/newcmd/handler.go
+++ b/cmd/newcmd/handler.go
@@ -17,6 +17,7 @@ var (
 		"LICENSE",
 		"main.go",
 		"README.md",
+		".gitignore",
 	}
 )
 

--- a/cmd/newcmd/mutator.go
+++ b/cmd/newcmd/mutator.go
@@ -17,6 +17,7 @@ var (
 		"LICENSE",
 		"main.go",
 		"README.md",
+		".gitignore",
 	}
 )
 

--- a/cmd/newcmd/sensuctl.go
+++ b/cmd/newcmd/sensuctl.go
@@ -17,6 +17,7 @@ var (
 		"LICENSE",
 		"main.go",
 		"README.md",
+		".gitignore",
 	}
 )
 


### PR DESCRIPTION
This is needed so that .gitignore can contain the default binary name

Signed-off-by: Todd Campbell <todd@sensu.io>